### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/ckfinder/connector/utils/FileUtils.java
+++ b/src/main/java/com/ckfinder/connector/utils/FileUtils.java
@@ -71,6 +71,9 @@ public class FileUtils {
             encodingMap = Collections.unmodifiableMap(mapHelper);
         }
 
+	private FileUtils() {
+	}
+
 	/**
 	 * Gets list of childeren folder or files for dir, according to searchDirs param.
 	 * @param dir folder to search.

--- a/src/main/java/com/ckfinder/connector/utils/ImageUtils.java
+++ b/src/main/java/com/ckfinder/connector/utils/ImageUtils.java
@@ -43,6 +43,9 @@ public class ImageUtils {
 		"xbm", "wbmp"};
 	private static final int MAX_BUFF_SIZE = 1024;
 
+	private ImageUtils() {
+	}
+
 	/**
 	 * Resizes the image and writes it to the disk.
 	 *

--- a/src/main/java/com/ckfinder/connector/utils/PathUtils.java
+++ b/src/main/java/com/ckfinder/connector/utils/PathUtils.java
@@ -19,6 +19,9 @@ import java.util.regex.Pattern;
  */
 public class PathUtils {
 
+	private PathUtils() {
+	}
+
 	/**
 	 * Escapes double slashes (//) and replace all backslashes (\) with slashes
 	 * (/). Additionally preserves UNC paths.

--- a/src/main/java/com/dcfun/elec/utils/FileUploadUtils.java
+++ b/src/main/java/com/dcfun/elec/utils/FileUploadUtils.java
@@ -7,7 +7,10 @@ import java.util.UUID;
 import org.apache.struts2.ServletActionContext;
 
 public class FileUploadUtils {
-	
+
+	private FileUploadUtils() {
+	}
+
 	/**
 	 * * 多文件上传的要求：
 		  1：将上传的文件统一放置到upload的文件夹下

--- a/src/main/java/com/dcfun/elec/utils/FormatDateUtils.java
+++ b/src/main/java/com/dcfun/elec/utils/FormatDateUtils.java
@@ -6,6 +6,9 @@ import java.util.logging.SimpleFormatter;
 
 public class FormatDateUtils {
 
+	private FormatDateUtils() {
+	}
+
 	public static String Date2String(Date date) {
 		return new SimpleDateFormat("yyMMdd").format(date);
 	}

--- a/src/main/java/com/dcfun/elec/utils/LogonUtils.java
+++ b/src/main/java/com/dcfun/elec/utils/LogonUtils.java
@@ -12,6 +12,9 @@ import org.apache.commons.lang3.StringUtils;
 
 public class LogonUtils {
 
+	private LogonUtils() {
+	}
+
 	public static boolean checkImageNumber(HttpServletRequest request) {
 
 		// 获取页面的验证码

--- a/src/main/java/com/dcfun/elec/utils/StringUtils.java
+++ b/src/main/java/com/dcfun/elec/utils/StringUtils.java
@@ -5,6 +5,9 @@ import java.util.List;
 
 public class StringUtils {
 
+	private StringUtils() {
+	}
+
 	public static List<String> getContentByList(String wholecontent, int cutcount) {
 		List<String> list = new ArrayList<>();
 		//获取完整内容字符串的总长度

--- a/src/main/java/com/dcfun/elec/utils/TUtils.java
+++ b/src/main/java/com/dcfun/elec/utils/TUtils.java
@@ -4,6 +4,9 @@ import java.lang.reflect.ParameterizedType;
 
 public class TUtils {
 
+	private TUtils() {
+	}
+
 	public static Class getTClass(Class entity) {
 		ParameterizedType type =  (ParameterizedType) entity.getGenericSuperclass();
 		Class entityClass = (Class) type.getActualTypeArguments()[0];

--- a/src/main/java/com/dcfun/elec/utils/ValueStackUtils.java
+++ b/src/main/java/com/dcfun/elec/utils/ValueStackUtils.java
@@ -4,6 +4,9 @@ import org.apache.struts2.ServletActionContext;
 
 public class ValueStackUtils {
 
+	private ValueStackUtils() {
+	}
+
 	public static void pushValueStack(Object object) {
 		
 		ServletActionContext.getContext().getValueStack().push(object);

--- a/src/main/java/com/dcfun/elec/utils/lucene/LuceneUtils.java
+++ b/src/main/java/com/dcfun/elec/utils/lucene/LuceneUtils.java
@@ -34,6 +34,9 @@ import com.dcfun.elec.domain.ElecFileUpload;
 
 public class LuceneUtils {
 
+	private LuceneUtils() {
+	}
+
 	/**向索引库中添加数据*/
 	public static void addIndex(ElecFileUpload fileUpload) {
 		Document doc = FileUploadDocument.FileUploadToDocument(fileUpload);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.
