### PR TITLE
[squid:S2130] Parsing should be used to convert "Strings" to primitives

### DIFF
--- a/src/main/java/com/ckfinder/connector/configuration/Configuration.java
+++ b/src/main/java/com/ckfinder/connector/configuration/Configuration.java
@@ -300,7 +300,7 @@ public class Configuration implements IConfiguration {
 	private float adjustQuality(final String imgQuality) {
 		float helper;
 		try {
-			helper = Math.abs(Float.valueOf(imgQuality).floatValue());
+			helper = Math.abs(Float.parseFloat(imgQuality));
 		} catch (NumberFormatException e) {
 			return DEFAULT_IMG_QUALITY;
 		}

--- a/src/main/java/com/ckfinder/connector/data/ResourceType.java
+++ b/src/main/java/com/ckfinder/connector/data/ResourceType.java
@@ -168,7 +168,7 @@ public class ResourceType {
 			default:
 				return 0;
 		}
-		long value = Long.valueOf(maxSize.substring(0, maxSize.length() - 1));
+		long value = Long.parseLong(maxSize.substring(0, maxSize.length() - 1));
 		return value * a;
 
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2130 - “ Parsing should be used to convert "Strings" to primitives”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2130

Please let me know if you have any questions.
Ayman Abdelghany.
