### PR TITLE
[squid:S1168] Empty arrays and collections should be returned instead of null

### DIFF
--- a/src/main/java/com/ckfinder/connector/errors/ErrorUtils.java
+++ b/src/main/java/com/ckfinder/connector/errors/ErrorUtils.java
@@ -137,7 +137,7 @@ public final class ErrorUtils {
 				}
 			}
 		} catch (IOException e) {
-			return null;
+			return new ArrayList<>();
 		}
 		return langFiles;
 

--- a/src/main/java/com/dcfun/elec/web/action/ElecExportFieldsAction.java
+++ b/src/main/java/com/dcfun/elec/web/action/ElecExportFieldsAction.java
@@ -73,7 +73,7 @@ public class ElecExportFieldsAction extends BaseAction<ElecExportFields>{
 		if (StringUtils.isNotBlank(expFieldName)) {
 			return expFieldName.split(string);
 		}
-		return null;
+		return new String[0];
 	}
 
 	/**  


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1168 - “Empty arrays and collections should be returned instead of null”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1168

Please let me know if you have any questions.
Ayman Abdelghany.
