### PR TITLE
[squid:S2864] "entrySet()" should be iterated when both the key and v

### DIFF
--- a/src/main/java/com/ckfinder/connector/utils/FileUtils.java
+++ b/src/main/java/com/ckfinder/connector/utils/FileUtils.java
@@ -428,12 +428,12 @@ public class FileUtils {
 		String newFileName = fileName;
 		fillLowerAccents();
 		fillUpperAccents();
-		for (String s : UTF8_LOWER_ACCENTS.keySet()) {
-			newFileName = newFileName.replace(s, UTF8_LOWER_ACCENTS.get(s));
+		for (Map.Entry<String, String> entry : UTF8_LOWER_ACCENTS.entrySet()) {
+			newFileName = newFileName.replace(entry.getKey(), entry.getValue());
 		}
 
-		for (String s : UTF8_UPPER_ACCENTS.keySet()) {
-			newFileName = newFileName.replace(s, UTF8_UPPER_ACCENTS.get(s));
+		for (Map.Entry<String, String> entry : UTF8_UPPER_ACCENTS.entrySet()) {
+			newFileName = newFileName.replace(entry.getKey(), entry.getValue());
 		}
 		return newFileName;
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864

Please let me know if you have any questions.
Ayman Abdelghany.
