### PR TITLE
[squid:S1161] "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one

### DIFF
--- a/src/main/java/com/ckfinder/connector/utils/FileUtils.java
+++ b/src/main/java/com/ckfinder/connector/utils/FileUtils.java
@@ -584,6 +584,7 @@ public class FileUtils {
         public static Boolean hasChildren( String dirPath, File dir, IConfiguration configuration, String resourceType, String currentUserRole )
         {
                 FileFilter fileFilter = new FileFilter() {
+                	@Override
                     public boolean accept(File file) {
                         return file.isDirectory();
                     }

--- a/src/main/java/com/ckfinder/connector/utils/NaturalOrderComparator.java
+++ b/src/main/java/com/ckfinder/connector/utils/NaturalOrderComparator.java
@@ -34,6 +34,7 @@ public class NaturalOrderComparator implements Comparator<String>, Serializable 
 	 * @return 1 if first string is greater, 0 if both are equals or -1 when
 	 * second string is greater.
 	 */
+	@Override
 	public int compare(final String string1, final String string2) {
 		String string1Copy = string1.toLowerCase();
 		String string2Copy = string2.toLowerCase();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1161 - “ "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1161

Please let me know if you have any questions.
Ayman Abdelghany.
