### PR TITLE
[squid:UselessParenthesesCheck] Useless parentheses around expression

### DIFF
--- a/src/main/java/com/ckfinder/connector/ConnectorServlet.java
+++ b/src/main/java/com/ckfinder/connector/ConnectorServlet.java
@@ -207,7 +207,7 @@ public class ConnectorServlet extends HttpServlet {
 	private void checkPostRequest(final HttpServletRequest request)
 			throws ConnectorException {
 		if (request.getParameter("CKFinderCommand") == null
-				|| !(request.getParameter("CKFinderCommand").equals("true"))) {
+				|| !request.getParameter("CKFinderCommand").equals("true")) {
 			throw new ConnectorException(
 					Constants.Errors.CKFINDER_CONNECTOR_ERROR_INVALID_REQUEST, true);
 		}

--- a/src/main/java/com/ckfinder/connector/FileUploadFilter.java
+++ b/src/main/java/com/ckfinder/connector/FileUploadFilter.java
@@ -50,7 +50,7 @@ public class FileUploadFilter implements Filter {
 					&& (response instanceof HttpServletResponse)) {
 				HttpServletRequest httpRequest = (HttpServletRequest) request;
 				String contentLength = httpRequest.getHeader(CONTENT_LENGTH);
-				if ((contentLength != null && Integer.parseInt(contentLength) == 0)) {
+				if (contentLength != null && Integer.parseInt(contentLength) == 0) {
 					HttpServletResponse httpResponse = (HttpServletResponse) response;
 					setSessionCookie((HttpServletResponse) response,
 							httpRequest);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.
Ayman Abdelghany.
